### PR TITLE
Fix compilation on Linux kernel 4.15 and more

### DIFF
--- a/mk_arcade_joystick_rpi.c
+++ b/mk_arcade_joystick_rpi.c
@@ -36,11 +36,16 @@
 
 #include <linux/ioport.h>
 #include <asm/io.h>
+#include <linux/version.h>
 
 
 MODULE_AUTHOR("Matthieu Proucelle");
 MODULE_DESCRIPTION("GPIO and MCP23017 Arcade Joystick Driver");
 MODULE_LICENSE("GPL");
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+#define HAVE_TIMER_SETUP
+#endif
 
 #define MK_MAX_DEVICES		9
 
@@ -366,8 +371,14 @@ static void mk_process_packet(struct mk *mk) {
  * mk_timer() initiates reads of console pads data.
  */
 
+#ifdef HAVE_TIMER_SETUP
+static void mk_timer(struct timer_list *t)
+{
+    struct mk *mk = from_timer(mk, t, timer);
+#else
 static void mk_timer(unsigned long private) {
     struct mk *mk = (void *) private;
+#endif
     mk_process_packet(mk);
     mod_timer(&mk->timer, jiffies + MK_REFRESH_TIME);
 }
@@ -514,7 +525,7 @@ static int __init mk_setup_pad(struct mk *mk, int idx, int pad_type_arg) {
         i2c_write(pad->mcp23017addr, MPC23017_GPIOB_PULLUPS_MODE, &FF, 1);
         udelay(1000);
         // Put all inputs on MCP23017 in pullup mode a second time
-        // Known bug : if you remove this line, you will not have pullups on GPIOB 
+        // Known bug : if you remove this line, you will not have pullups on GPIOB
         i2c_write(pad->mcp23017addr, MPC23017_GPIOB_PULLUPS_MODE, &FF, 1);
         udelay(1000);
     }
@@ -545,7 +556,11 @@ static struct mk __init *mk_probe(int *pads, int n_pads) {
     }
 
     mutex_init(&mk->mutex);
+    #ifdef HAVE_TIMER_SETUP
+    timer_setup(&mk->timer, mk_timer, 0);
+    #else
     setup_timer(&mk->timer, mk_timer, (long) mk);
+    #endif
 
     for (i = 0; i < n_pads && i < MK_MAX_DEVICES; i++) {
         if (!pads[i])


### PR DESCRIPTION
The Linux Kernel setup_timer doesn't exist anymore in 4.15 and later, being superseded by timer_setup in the Linux timers API.
More details:

https://lwn.net/Articles/735887/
https://lkml.org/lkml/2017/11/21/685

All credits for @cmitu and big thanks

Commit: https://github.com/cmitu/mk_arcade_joystick_rpi/commit/bdb1affd88ab3c02584c0ff2b895ff186dcfcc5e


